### PR TITLE
Dockerfile for iruka server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,46 @@
+#
+# git
+#
+.git
+.gitignore
+
+#
+# docs
+#
+docs
+*.md
+LICENSE
+
+#
+# script
+#
+script
+
+#
+# Bundler
+#
+Gemfile
+Gemfile.lock
+.bundle
+bin
+vendor
+
+#
+# coreos-vagrant
+#
+coreos
+
+#
+# gin
+#
+gin-bin
+
+#
+# vim
+#
+*.swp
+
+#
+# OSX
+#
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM gliderlabs/alpine:3.1
+ENTRYPOINT ["/bin/irukad"]
+
+COPY . /go/src/github.com/spesnova/iruka
+RUN apk-install -t build-deps go git mercurial \
+      && cd /go/src/github.com/spesnova/iruka/irukad \
+      && export GOPATH=/go \
+      && go get \
+      && go build -ldflags "-X main.Version" -o /bin/irukad \
+      && rm -rf /go \
+      && apk del --purge build-deps go git mercurial


### PR DESCRIPTION
## WHAT is this

Add `Dockerfile` to build iruka server.
I'd prefer to use small image for some reason:
- pushing, pulling and building image is fast
- few packages included means less maintainance

So I'm using `gliderlabs/alpine` for base image.
### Detail about the image
- Build time: 1m9s ~ 1m20s
- Image size: 23.43 MB 
## WHY this change is needed

To deploy iruka server as docker container.
## REF

[gliderlabs/registrator](https://github.com/gliderlabs/registrator)
