### PR TITLE
Ignore iruka binary and iruka.yml in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,12 +28,8 @@ gin-bin
 .DS_Store
 
 #
-# binaries
-#
-artifacts
-
-#
 # iruka artifacts
 #
+artifacts
 iruka
 iruka.yml


### PR DESCRIPTION
## WHAT

Add `iruka` and `iruka.yml` to `.gitignore` not to track them with Git.
