### PR TITLE
Exit if Config Vars value is not given

### DIFF
--- a/iruka/set.go
+++ b/iruka/set.go
@@ -39,6 +39,12 @@ func runSet(c *cli.Context) {
 	keyValues := strings.Split(keyValuesString, ",")
 	for i := range keyValues {
 		keyValue := strings.Split(keyValues[i], "=")
+
+		if len(keyValue) != 2 {
+			cli.ShowCommandHelp(c, "set")
+			os.Exit(1)
+		}
+
 		configVars[keyValue[0]] = keyValue[1]
 	}
 


### PR DESCRIPTION
Fix #23 
## WHAT

If Config Vars value is missing, CLI shows help and exit with failed state.

``` bash
$ ./iruka set BAR
NAME:
   set - Set config vars to the app

USAGE:
   command set [command options] [arguments...]

DESCRIPTION:

   $ iruka set <KEY1>=<VALUE1>,<KEY2>=<VALUE2>

EXAMPLE:

   $ iruka set HELLO=world,SOME_FLAG=1
   FOO:       bar
   BAZ:       qux
   HELLO:     world
   SOME_FLAG: 1


OPTIONS:
   --app        app name or id
```
